### PR TITLE
Fix GitHub Pages deployment token usage

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -26,8 +26,6 @@ jobs:
       - name: Setup Pages
         uses: actions/configure-pages@v4
         with:
-          # PAGES_TOKEN should be a Personal Access Token with `repo` and `pages:write` scopes
-          token: ${{ secrets.PAGES_TOKEN }}
           enablement: true
       - name: Upload artifact
         uses: actions/upload-pages-artifact@v3

--- a/README.md
+++ b/README.md
@@ -14,3 +14,4 @@ Static landing page with a Telegram mini app mock.
 ## Deployment
 
 The repository includes a GitHub Actions workflow that publishes the site to GitHub Pages on every push to the `main` branch.
+The workflow leverages GitHub's built-in `GITHUB_TOKEN`, so no personal access token is required.


### PR DESCRIPTION
## Summary
- remove explicit secret requirement from Pages workflow
- document Pages deployment setup and no longer require personal access token

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68bfb7df3ad483248b7d0d69efe50094